### PR TITLE
Add saved routes

### DIFF
--- a/src/actions/clearRoutes.js
+++ b/src/actions/clearRoutes.js
@@ -1,0 +1,5 @@
+export const clearRoutes = () => {
+  return {
+    type: "CLEAR_ROUTES",
+  };
+};

--- a/src/actions/displayRoute.js
+++ b/src/actions/displayRoute.js
@@ -1,0 +1,6 @@
+export const displayRoute = (route) => {
+  return {
+    type: "DISPLAY_ROUTE",
+    payload: route,
+  };
+};

--- a/src/actions/saveRoute.js
+++ b/src/actions/saveRoute.js
@@ -1,6 +1,6 @@
-export const addDirections = (route) => {
+export const saveRoute = (route) => {
   return {
-    type: "ADD_ROUTE",
+    type: "SAVE_ROUTE",
     payload: route,
   };
 };

--- a/src/actions/saveRoute.js
+++ b/src/actions/saveRoute.js
@@ -1,0 +1,6 @@
+export const addDirections = (route) => {
+  return {
+    type: "ADD_ROUTE",
+    payload: route,
+  };
+};

--- a/src/async-functions/async.js
+++ b/src/async-functions/async.js
@@ -215,11 +215,11 @@ export async function deleteSavedRoute(name) {
   return response.json();
 }
 
-export async function addSavedRoute(origin, destination, name) {
+export async function addSavedRoute(data) {
   const savedRoute = {
-    origin: origin,
-    destination: destination,
-    name: name,
+    origin: data.origin,
+    destination: data.destination,
+    name: data.name,
   };
   const response = await fetch(`${endpoint}savedRoutes`, {
     method: "POST",

--- a/src/async-functions/async.js
+++ b/src/async-functions/async.js
@@ -1,5 +1,5 @@
 // TODO: remove this endpoint after testing
-const endpoint = "http://localhost:3001/" || "http://server.a11ymaps.com/";
+const endpoint = "http://server.a11ymaps.com/";
 export async function loginCurl(data) {
   const response = await fetch(`${endpoint}users`, {
     method: "PUT", // *GET, POST, PUT, DELETE, etc.

--- a/src/async-functions/async.js
+++ b/src/async-functions/async.js
@@ -1,4 +1,5 @@
-const endpoint = "http://server.a11ymaps.com/";
+// TODO: remove this endpoint after testing
+const endpoint = "http://localhost:3001/" || "http://server.a11ymaps.com/";
 export async function loginCurl(data) {
   const response = await fetch(`${endpoint}users`, {
     method: "PUT", // *GET, POST, PUT, DELETE, etc.
@@ -130,7 +131,6 @@ export async function recoverySendCodeCurl(data) {
   return response.json(); // parses JSON response into native JavaScript objects
 }
 
-// JJ: at some point, may need to pass in user here as well
 export async function getRouteResults(locations) {
   const routeParams = new URLSearchParams({
     orig: locations[0],
@@ -162,7 +162,7 @@ export async function getUserPreferenceCurl() {
   return response.json(); // parses JSON response into native JavaScript objects
 }
 
-/*  Get user Preferences  */
+/*  Put user Preferences  */
 export async function putSetUserPreferenceCurl(data) {
   const response = await fetch(`${endpoint}profileCreation`, {
     method: "PUT", // *GET, POST, PUT, DELETE, etc.
@@ -178,4 +178,35 @@ export async function putSetUserPreferenceCurl(data) {
     body: JSON.stringify(data),
   });
   return response.json(); // parses JSON response into native JavaScript objects
+}
+
+/*  Get user Preferences  */
+export async function getSavedRoutes() {
+  const response = await fetch(`${endpoint}savedRoutes/`, {
+    method: "GET",
+    mode: "cors",
+    cache: "no-cache",
+    credentials: "same-origin",
+  });
+  return response.json();
+}
+
+export async function deleteSavedRoutes() {
+  const response = await fetch(`${endpoint}savedRoutes/`, {
+    method: "DELETE",
+    mode: "cors",
+    cache: "no-cache",
+    credentials: "same-origin",
+  });
+  return response.json();
+}
+
+export async function addSavedRoute() {
+  const response = await fetch(`${endpoint}savedRoutes/`, {
+    method: "POST",
+    mode: "cors",
+    cache: "no-cache",
+    credentials: "same-origin",
+  });
+  return response.json();
 }

--- a/src/async-functions/async.js
+++ b/src/async-functions/async.js
@@ -180,33 +180,56 @@ export async function putSetUserPreferenceCurl(data) {
   return response.json(); // parses JSON response into native JavaScript objects
 }
 
-/*  Get user Preferences  */
+/*  Get Saved Routes  */
 export async function getSavedRoutes() {
-  const response = await fetch(`${endpoint}savedRoutes/`, {
+  const response = await fetch(`${endpoint}savedRoutes`, {
     method: "GET",
     mode: "cors",
     cache: "no-cache",
-    credentials: "same-origin",
+    credentials: "include",
   });
   return response.json();
 }
 
-export async function deleteSavedRoutes() {
-  const response = await fetch(`${endpoint}savedRoutes/`, {
+export async function deleteAllSavedRoutes() {
+  const response = await fetch(`${endpoint}savedRoutes`, {
+    method: "PUT",
+    mode: "cors",
+    cache: "no-cache",
+    credentials: "include",
+  });
+  return response.json();
+}
+
+export async function deleteSavedRoute(name) {
+  const response = await fetch(`${endpoint}savedRoutes`, {
     method: "DELETE",
     mode: "cors",
     cache: "no-cache",
-    credentials: "same-origin",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ name: name }),
   });
   return response.json();
 }
 
-export async function addSavedRoute() {
-  const response = await fetch(`${endpoint}savedRoutes/`, {
+export async function addSavedRoute(origin, destination, name) {
+  const savedRoute = {
+    origin: origin,
+    destination: destination,
+    name: name,
+  };
+  const response = await fetch(`${endpoint}savedRoutes`, {
     method: "POST",
     mode: "cors",
     cache: "no-cache",
-    credentials: "same-origin",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(savedRoute),
   });
   return response.json();
 }

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -43,7 +43,7 @@ export default function Navigation() {
     navigate("../profile");
   };
 
-  const routePage = async () =>{
+  const routePage = async () => {
     navigate("../search");
   };
 
@@ -77,9 +77,11 @@ export default function Navigation() {
             <ListItemButton>
               <ListItemIcon>
                 {index % 2 === 0 ? (
-                  <LocationSearchingIcon onClick={()=>{
-                    routePage();
-                  }} />
+                  <LocationSearchingIcon
+                    onClick={() => {
+                      routePage();
+                    }}
+                  />
                 ) : (
                   <SavedSearchIcon />
                 )}

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -27,7 +27,6 @@ import { useDispatch, useSelector } from "react-redux";
 import { toggleDrawerState, loginState } from "../actions";
 import { logoutCurl } from "../async-functions/async";
 
-
 export default function Navigation() {
   const navigate = useNavigate();
   const dispatch = useDispatch();
@@ -40,7 +39,7 @@ export default function Navigation() {
       console.error(e);
     }
   };
-  const profileView = async () =>{
+  const profileView = async () => {
     navigate("../profile");
   };
 

--- a/src/components/bottom-components/Details.js
+++ b/src/components/bottom-components/Details.js
@@ -12,8 +12,9 @@ import {
   MenuItem,
 } from "@mui/material";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useSelector } from "react-redux";
+import { getSavedRoutes } from "../../async-functions/async";
 
 export default function Details(props) {
   const [currDisplayedPrevOrigin, setCurrDisplayedPrevOrigin] = useState("");
@@ -34,6 +35,14 @@ export default function Details(props) {
 
   const savedRoutes = useSelector((state) => state.savedRoutesReducer);
 
+  useEffect(() => {
+    async function loadSavedRoutes() {
+      const storedSavedRoutes = await getSavedRoutes();
+      setDropdown(storedSavedRoutes);
+    }
+    loadSavedRoutes();
+  }, [savedRoutes]);
+
   const handleDropdownChange = () => {};
 
   return (
@@ -53,8 +62,8 @@ export default function Details(props) {
               MenuProps={MenuProps}
             >
               {dropdown.map((route) => (
-                <MenuItem key={route} value={route}>
-                  {route}
+                <MenuItem key={route.name} value={route.name}>
+                  {route.name}
                 </MenuItem>
               ))}
             </Select>

--- a/src/components/bottom-components/Details.js
+++ b/src/components/bottom-components/Details.js
@@ -12,9 +12,9 @@ import {
 import { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { clearRoutes } from "../../actions/clearRoutes";
+import { displayRoute } from "../../actions/displayRoute";
 import {
   deleteAllSavedRoutes,
-  getRouteResults,
   getSavedRoutes,
 } from "../../async-functions/async";
 
@@ -63,8 +63,8 @@ export default function Details(props) {
     dispatch(clearRoutes());
   };
 
-  const viewSavedRoute = async () => {
-    await getRouteResults;
+  const viewSavedRoute = () => {
+    dispatch(displayRoute([currDisplayedPrevOrigin, currDisplayedPrevDest]));
   };
 
   return (

--- a/src/components/bottom-components/Details.js
+++ b/src/components/bottom-components/Details.js
@@ -10,11 +10,16 @@ import {
   Select,
   OutlinedInput,
   MenuItem,
+  Button,
 } from "@mui/material";
 
 import { useEffect, useState } from "react";
-import { useSelector } from "react-redux";
-import { getSavedRoutes } from "../../async-functions/async";
+import { useDispatch, useSelector } from "react-redux";
+import { clearRoutes } from "../../actions/clearRoutes";
+import {
+  deleteAllSavedRoutes,
+  getSavedRoutes,
+} from "../../async-functions/async";
 
 export default function Details(props) {
   const [currDisplayedPrevOrigin, setCurrDisplayedPrevOrigin] = useState("");
@@ -33,6 +38,8 @@ export default function Details(props) {
     },
   };
 
+  const dispatch = useDispatch();
+
   const savedRoutes = useSelector((state) => state.savedRoutesReducer);
 
   useEffect(() => {
@@ -44,6 +51,11 @@ export default function Details(props) {
   }, [savedRoutes]);
 
   const handleDropdownChange = () => {};
+
+  const clearSavedRoutes = async () => {
+    await deleteAllSavedRoutes();
+    dispatch(clearRoutes());
+  };
 
   return (
     <Grid container space={1}>
@@ -81,6 +93,11 @@ export default function Details(props) {
       </Grid>
       <Grid item xs={6}>
         <Chip label={currDisplayedPrevDest}></Chip>
+      </Grid>
+      <Grid>
+        <Button variant="contained" type="submit" onClick={clearSavedRoutes}>
+          Clear Saved Routes
+        </Button>
       </Grid>
     </Grid>
   );

--- a/src/components/bottom-components/Details.js
+++ b/src/components/bottom-components/Details.js
@@ -1,14 +1,10 @@
 import {
-  Box,
   Grid,
-  Slider,
-  TextField,
   Typography,
   Chip,
   FormControl,
   InputLabel,
   Select,
-  OutlinedInput,
   MenuItem,
   Button,
 } from "@mui/material";
@@ -18,6 +14,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { clearRoutes } from "../../actions/clearRoutes";
 import {
   deleteAllSavedRoutes,
+  getRouteResults,
   getSavedRoutes,
 } from "../../async-functions/async";
 
@@ -25,6 +22,7 @@ export default function Details(props) {
   const [currDisplayedPrevOrigin, setCurrDisplayedPrevOrigin] = useState("");
   const [currDisplayedPrevDest, setCurrDisplayedPrevDest] = useState("");
   const [dropdown, setDropdown] = useState([]);
+  const [currDropdownVal, setCurrDropdownVal] = useState("");
 
   const ITEM_HEIGHT = 48;
   const ITEM_PADDING_TOP = 8;
@@ -50,11 +48,23 @@ export default function Details(props) {
     loadSavedRoutes();
   }, [savedRoutes]);
 
-  const handleDropdownChange = () => {};
+  const handleDropdownChange = (event) => {
+    setCurrDropdownVal(event.target.value);
+
+    let newRoute = dropdown.filter(
+      (route) => route.name == event.target.value
+    )[0];
+    setCurrDisplayedPrevOrigin(newRoute.origin);
+    setCurrDisplayedPrevDest(newRoute.destination);
+  };
 
   const clearSavedRoutes = async () => {
     await deleteAllSavedRoutes();
     dispatch(clearRoutes());
+  };
+
+  const viewSavedRoute = async () => {
+    await getRouteResults;
   };
 
   return (
@@ -63,14 +73,14 @@ export default function Details(props) {
         <Typography variant={"h5"}>Saved Queries</Typography>
         <div>
           <FormControl sx={{ m: 1, width: 300 }}>
-            <InputLabel id="demo-multiple-name-label">Route</InputLabel>
+            <InputLabel id="route-label">Route</InputLabel>
             <Select
-              labelId="demo-multiple-name-label"
-              id="demo-multiple-name"
-              multiple
-              value={dropdown}
+              labelId="route-label"
+              id="route"
+              value={currDropdownVal}
+              label="Route"
               onChange={handleDropdownChange}
-              input={<OutlinedInput label="Route" />}
+              // input={<OutlinedInput label="Route" />}
               MenuProps={MenuProps}
             >
               {dropdown.map((route) => (
@@ -97,6 +107,9 @@ export default function Details(props) {
       <Grid>
         <Button variant="contained" type="submit" onClick={clearSavedRoutes}>
           Clear Saved Routes
+        </Button>
+        <Button variant="contained" type="submit" onClick={viewSavedRoute}>
+          View Saved Route
         </Button>
       </Grid>
     </Grid>

--- a/src/components/bottom-components/Details.js
+++ b/src/components/bottom-components/Details.js
@@ -1,44 +1,78 @@
-import { Box, Grid, Slider, TextField, Typography } from "@mui/material";
+import {
+  Box,
+  Grid,
+  Slider,
+  TextField,
+  Typography,
+  Chip,
+  FormControl,
+  InputLabel,
+  Select,
+  OutlinedInput,
+  MenuItem,
+} from "@mui/material";
+
+import { useState } from "react";
+import { useSelector } from "react-redux";
 
 export default function Details(props) {
+  const [currDisplayedPrevOrigin, setCurrDisplayedPrevOrigin] = useState("");
+  const [currDisplayedPrevDest, setCurrDisplayedPrevDest] = useState("");
+  const [dropdown, setDropdown] = useState([]);
+
+  const ITEM_HEIGHT = 48;
+  const ITEM_PADDING_TOP = 8;
+
+  const MenuProps = {
+    PaperProps: {
+      style: {
+        maxHeight: ITEM_HEIGHT * 4.5 + ITEM_PADDING_TOP,
+        width: 250,
+      },
+    },
+  };
+
+  const savedRoutes = useSelector((state) => state.savedRoutesReducer);
+
+  const handleDropdownChange = () => {};
+
   return (
     <Grid container space={1}>
       <Grid item xs={12}>
-        <Typography variant={"h5"}>Preferences</Typography>
+        <Typography variant={"h5"}>Saved Queries</Typography>
+        <div>
+          <FormControl sx={{ m: 1, width: 300 }}>
+            <InputLabel id="demo-multiple-name-label">Route</InputLabel>
+            <Select
+              labelId="demo-multiple-name-label"
+              id="demo-multiple-name"
+              multiple
+              value={dropdown}
+              onChange={handleDropdownChange}
+              input={<OutlinedInput label="Route" />}
+              MenuProps={MenuProps}
+            >
+              {dropdown.map((route) => (
+                <MenuItem key={route} value={route}>
+                  {route}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </div>
       </Grid>
       <Grid item xs={6}>
-        <Typography variant={"h6"}>Maximum Allowable Incline</Typography>
+        <Typography variant={"h6"}>Origin</Typography>
       </Grid>
       <Grid item xs={6}>
-        <Slider
-          aria-label={"Max incline"}
-          defaultValue={5}
-          step={1}
-          marks
-          min={0}
-          max={15}
-        />
+        <Chip label={currDisplayedPrevOrigin}></Chip>
       </Grid>
       <Grid item xs={6}>
-        <Typography variant={"h6"}>Maximum Allowable Elevation</Typography>
+        <Typography variant={"h6"}>Destination</Typography>
       </Grid>
       <Grid item xs={6}>
-        <Slider
-          aria-label={"Max Elevation"}
-          defaultValue={20}
-          step={5}
-          marks
-          min={0}
-          max={50}
-        />
+        <Chip label={currDisplayedPrevDest}></Chip>
       </Grid>
     </Grid>
   );
 }
-
-// function auto_grow(referen) {
-//   if (referen.current != null) {
-//     referen.current.style.height = "20px";
-//     referen.current.style.height = referen.current.scrollHeight + "px";
-//   }
-// }

--- a/src/components/profile/Profile.js
+++ b/src/components/profile/Profile.js
@@ -20,7 +20,10 @@ import {
   putSetUserPreferenceCurl,
 } from "../../async-functions/async";
 import { loginState } from "../../actions";
-import { setInitialCookieCurl, getCookieValidationCurl } from "../../async-functions/async";
+import {
+  setInitialCookieCurl,
+  getCookieValidationCurl,
+} from "../../async-functions/async";
 import { validate } from "email-validator";
 import { textAlign, width } from "@mui/system";
 import Cookies from "js-cookie";
@@ -66,7 +69,6 @@ export default function Profile() {
   };
   const handlePriorityChange = (event) => {
     setPriority(event.target.value);
-    console.log(event.target.value);
     switch (event.target.value) {
       case "distance":
         setHelperText("I value shorter distances more.");
@@ -78,19 +80,19 @@ export default function Profile() {
         setHelperText("Distance and incline are equally important to me.");
     }
   };
-  const currentPreferences =async () => {
-    try{
-      const userPref= await getUserPreferenceCurl();
-      if (userPref["exists"]==1){
-      setcurrPrefText(`maxIncline:${userPref["maxIncline"]}, weight:${userPref["weight"]}, distancePreference:${userPref["distancePreference"]} `)
-      }
-      else{
+  const currentPreferences = async () => {
+    try {
+      const userPref = await getUserPreferenceCurl();
+      if (userPref["exists"] == 1) {
+        setcurrPrefText(
+          `maxIncline:${userPref["maxIncline"]}, weight:${userPref["weight"]}, distancePreference:${userPref["distancePreference"]} `
+        );
+      } else {
         setcurrPrefText("User preferences not set");
       }
+    } catch (error) {
+      console.log(error);
     }
-      catch (error){
-        console.log(error);
-      }
   };
 
   const handleSave = async () => {
@@ -101,17 +103,16 @@ export default function Profile() {
       weight: weight,
       distancePreference: priority,
     };
-    try{
-    await putSetUserPreferenceCurl(profile);
-    setSaveText("Save Successful");
-    }
-    catch (error){
+    try {
+      await putSetUserPreferenceCurl(profile);
+      setSaveText("Save Successful");
+    } catch (error) {
       console.log(error);
     }
   };
 
   useEffect(() => {
-    if (loginUser !== "" && Cookies.get("map_id")==="") {
+    if (loginUser !== "" && Cookies.get("map_id") === "") {
       setInitialCookieCurl({ userName: loginUser })
         .then((res) => {
           if (res["status"] !== 0) {

--- a/src/components/top-components/RightTopContainer.js
+++ b/src/components/top-components/RightTopContainer.js
@@ -14,6 +14,7 @@ import { clearDirections } from "../../actions/clearDirections";
 import { addSavedRoute, getRouteResults } from "../../async-functions/async";
 import { changeRouteIndex } from "../../actions/changeRouteIndex";
 import { saveRoute } from "../../actions/saveRoute";
+import { useEffect } from "react";
 
 const containerStyle = {
   display: "inline-flex",
@@ -39,6 +40,7 @@ function MainMapComponent() {
   const [routeLabel, setRouteLabel] = React.useState("");
 
   const dispatch = useDispatch();
+  const displayRoute = useSelector((state) => state.displayRouteReducer);
 
   /** @type React.MutableRefObject<HTMLInputElement> */
   const originRef = useRef();
@@ -55,17 +57,21 @@ function MainMapComponent() {
     setMap(null);
   }, []);
 
-  async function calculateRoute() {
-    const routeResults = await getRouteResults([
-      originRef.current.value,
-      destRef.current.value,
-    ]);
+  useEffect(() => {
+    async function updateDisplayedRoute() {
+      await calculateRoute(displayRoute[0], displayRoute[1]);
+    }
+    updateDisplayedRoute();
+  }, [displayRoute]);
+
+  async function calculateRoute(origin, destination) {
+    const routeResults = await getRouteResults([origin, destination]);
     // eslint-disable-next-line no-undef
     const directionService = new google.maps.DirectionsService();
     // hand direction service the origin, destination and travel mode as well as options
     const results = await directionService.route({
-      origin: originRef.current.value,
-      destination: destRef.current.value,
+      origin: origin,
+      destination: destination,
       // eslint-disable-next-line no-undef
       travelMode: google.maps.TravelMode.WALKING,
       provideRouteAlternatives: true,
@@ -104,7 +110,13 @@ function MainMapComponent() {
     <Grid container spacing={2}>
       <Grid item xs={3}>
         <Inputs origin={originRef} destination={destRef} />
-        <Button variant="contained" type="submit" onClick={calculateRoute}>
+        <Button
+          variant="contained"
+          type="submit"
+          onClick={() =>
+            calculateRoute(originRef.current.value, destRef.current.value)
+          }
+        >
           Calculate Route
         </Button>
         <Divider variant="middle" />

--- a/src/components/top-components/RightTopContainer.js
+++ b/src/components/top-components/RightTopContainer.js
@@ -13,6 +13,7 @@ import { clearDirections } from "../../actions/clearDirections";
 // import { APIKey } from "../../apiKey";
 import { addSavedRoute, getRouteResults } from "../../async-functions/async";
 import { changeRouteIndex } from "../../actions/changeRouteIndex";
+import { saveRoute } from "../../actions/saveRoute";
 
 const containerStyle = {
   display: "inline-flex",
@@ -89,12 +90,14 @@ function MainMapComponent() {
     dispatch(changeRouteIndex(directionArray[0].routeIndex));
   }
 
-  async function saveRoute() {
-    await addSavedRoute(
-      originRef.current.value,
-      destRef.current.value,
-      routeLabel
-    );
+  async function saveNewRoute() {
+    const data = {
+      origin: originRef.current.value,
+      destination: destRef.current.value,
+      name: routeLabel,
+    };
+    await addSavedRoute(data);
+    dispatch(saveRoute(data));
   }
 
   return isLoaded ? (
@@ -117,7 +120,7 @@ function MainMapComponent() {
           type="text"
           onChange={(event) => setRouteLabel(event.target.value)}
         ></TextField>
-        <Button variant="contained" type="submit" onClick={saveRoute}>
+        <Button variant="contained" type="submit" onClick={saveNewRoute}>
           Save Route
         </Button>
       </Grid>

--- a/src/components/top-components/RightTopContainer.js
+++ b/src/components/top-components/RightTopContainer.js
@@ -6,12 +6,12 @@ import {
   DirectionsRenderer,
 } from "@react-google-maps/api";
 import Inputs from "./InputDiv";
-import { Button, Divider, Grid } from "@mui/material";
+import { Button, Divider, Grid, Input, TextField } from "@mui/material";
 import { useDispatch, useSelector } from "react-redux";
 import { addDirections } from "../../actions/addDirections";
 import { clearDirections } from "../../actions/clearDirections";
 // import { APIKey } from "../../apiKey";
-import { getRouteResults } from "../../async-functions/async";
+import { addSavedRoute, getRouteResults } from "../../async-functions/async";
 import { changeRouteIndex } from "../../actions/changeRouteIndex";
 
 const containerStyle = {
@@ -26,8 +26,8 @@ const center = {
 };
 
 function MainMapComponent() {
-  let APIKey=Cookies.get("map_id");
-  const {isLoaded} = useJsApiLoader({
+  let APIKey = Cookies.get("map_id");
+  const { isLoaded } = useJsApiLoader({
     id: "google-map-script",
     googleMapsApiKey: APIKey,
     libraries: ["places"],
@@ -35,6 +35,7 @@ function MainMapComponent() {
   const [map, setMap] = React.useState(/** @type google.maps.Map */ (null));
   const [directions, setDirections] = React.useState(null);
   const routeIndex = useSelector((state) => state.routeIndexReducer);
+  const [routeLabel, setRouteLabel] = React.useState("");
 
   const dispatch = useDispatch();
 
@@ -88,6 +89,14 @@ function MainMapComponent() {
     dispatch(changeRouteIndex(directionArray[0].routeIndex));
   }
 
+  async function saveRoute() {
+    await addSavedRoute(
+      originRef.current.value,
+      destRef.current.value,
+      routeLabel
+    );
+  }
+
   return isLoaded ? (
     <Grid container spacing={2}>
       <Grid item xs={3}>
@@ -98,6 +107,18 @@ function MainMapComponent() {
         <Divider variant="middle" />
         <Button variant="contained" onClick={() => dispatch(clearDirections())}>
           Clear Results
+        </Button>
+        <Divider variant="middle" />
+
+        <TextField
+          variant="filled"
+          required
+          label="Label Route"
+          type="text"
+          onChange={(event) => setRouteLabel(event.target.value)}
+        ></TextField>
+        <Button variant="contained" type="submit" onClick={saveRoute}>
+          Save Route
         </Button>
       </Grid>
       <Grid item xs={9}>

--- a/src/reducers/displayRouteReducer.js
+++ b/src/reducers/displayRouteReducer.js
@@ -1,0 +1,11 @@
+const displayRouteReducer = (routeToDisplay = ["", ""], action) => {
+  switch (action.type) {
+    case "DISPLAY_ROUTE":
+      routeToDisplay = action.payload;
+      return routeToDisplay;
+    default:
+      return routeToDisplay;
+  }
+};
+
+export default displayRouteReducer;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -2,6 +2,7 @@ import { combineReducers } from "redux";
 import directionsReducer from "./directionsReducer";
 import routeIndexReducer from "./routeIndexReducer";
 import savedRoutesReducer from "./savedRoutesReducer";
+import displayRouteReducer from "./displayRouteReducer";
 import { template, drawerState, loginState } from "./reducer";
 
 const rootReducer = combineReducers({
@@ -10,6 +11,7 @@ const rootReducer = combineReducers({
   directionsReducer,
   routeIndexReducer,
   savedRoutesReducer,
+  displayRouteReducer,
   template,
 });
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,7 +1,7 @@
 import { combineReducers } from "redux";
 import directionsReducer from "./directionsReducer";
 import routeIndexReducer from "./routeIndexReducer";
-import savedRoutesReducer from "./routeIndexReducer";
+import savedRoutesReducer from "./savedRoutesReducer";
 import { template, drawerState, loginState } from "./reducer";
 
 const rootReducer = combineReducers({

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,6 +1,7 @@
 import { combineReducers } from "redux";
 import directionsReducer from "./directionsReducer";
 import routeIndexReducer from "./routeIndexReducer";
+import savedRoutesReducer from "./routeIndexReducer";
 import { template, drawerState, loginState } from "./reducer";
 
 const rootReducer = combineReducers({
@@ -8,6 +9,7 @@ const rootReducer = combineReducers({
   loginState,
   directionsReducer,
   routeIndexReducer,
+  savedRoutesReducer,
   template,
 });
 

--- a/src/reducers/savedRoutesReducer.js
+++ b/src/reducers/savedRoutesReducer.js
@@ -1,0 +1,14 @@
+const savedRoutesReducer = (savedRoutesArray = null, action) => {
+  switch (action.type) {
+    case "SAVE_ROUTE":
+      savedRoutesArray = action.payload;
+      return savedRoutesArray;
+    case "CLEAR_ROUTES":
+      savedRoutesArray = [];
+      return savedRoutesArray;
+    default:
+      return savedRoutesArray;
+  }
+};
+
+export default savedRoutesReducer;

--- a/src/reducers/savedRoutesReducer.js
+++ b/src/reducers/savedRoutesReducer.js
@@ -1,8 +1,9 @@
-const savedRoutesReducer = (savedRoutesArray = null, action) => {
+const savedRoutesReducer = (savedRoutesArray = [], action) => {
   switch (action.type) {
     case "SAVE_ROUTE":
-      savedRoutesArray = action.payload;
-      return savedRoutesArray;
+      let newRoutesArray = [...savedRoutesArray];
+      newRoutesArray.push(action.payload);
+      return newRoutesArray;
     case "CLEAR_ROUTES":
       savedRoutesArray = [];
       return savedRoutesArray;

--- a/src/server/routes/savedRoutes.js
+++ b/src/server/routes/savedRoutes.js
@@ -61,14 +61,6 @@ router.put("/", valCookie, async function (req, res) {
   try {
     let { cookies } = req;
     let individual = await LoginModel.find({ accessToken: cookies.session_id });
-    // let duplicateCheck = await savedRouteModel.find({
-    //   email: individual[0]["email"],
-    //   name: req.body["name"],
-    // });
-    // if (duplicateCheck.length !== 0) {
-    //   res.send({ exists: 1 });
-    //   return;
-    // }
 
     let savedRoutes = await savedRouteModel.deleteMany({
       email: individual[0]["email"],

--- a/src/server/routes/savedRoutes.js
+++ b/src/server/routes/savedRoutes.js
@@ -58,26 +58,19 @@ router.post("/", valCookie, async function (req, res) {
 });
 
 router.put("/", valCookie, async function (req, res) {
-  å;
   try {
     let { cookies } = req;
     let individual = await LoginModel.find({ accessToken: cookies.session_id });
-    let duplicateCheck = await savedRouteModel.find({
-      email: individual[0]["email"],
-      name: req.body["name"],
-    });
-    if (duplicateCheck.length !== 0) {
-      res.send({ exists: 1 });
-      return;
-    }
-    let newSavedRoutes = new savedRouteModel({
-      email: individual[0]["email"],
-      origin: req.body["origin"],
-      destination: req.body["destination"],
-      name: req.body["name"],
-    });
-    await newSavedRoutes.save();
-    let savedRoutes = await savedRouteModel.find({
+    // let duplicateCheck = await savedRouteModel.find({
+    //   email: individual[0]["email"],
+    //   name: req.body["name"],
+    // });
+    // if (duplicateCheck.length !== 0) {
+    //   res.send({ exists: 1 });
+    //   return;
+    // }
+
+    let savedRoutes = await savedRouteModel.deleteMany({
       email: individual[0]["email"],
     });
     let arr = [];

--- a/src/server/routes/savedRoutes.js
+++ b/src/server/routes/savedRoutes.js
@@ -2,67 +2,116 @@ const express = require("express");
 const router = express.Router();
 const mongoose = require("mongoose");
 const { valCookie } = require("./users");
+const { LoginModel } = require("./users");
 const savedRouteSchema = require("../database/savedRouteSchema");
 
-const savedRouteModel=savedRouteSchema;
-router.get('/', valCookie,async function(req, res) {
-    try{
-      let { cookies } = req;
-      let individual = await LoginModel.find({ accessToken: cookies.session_id });
-      let savedRoutes= await savedRouteModel.find({email: individual[0]["email"]});
-      let arr=[];
-      for (let i=0;i<savedRoutes.length;i++){
-        arr.push(savedRoutes[i]);
-      }
-      res.send(arr);
-      } catch(error){
-        res.send({"error":error});
-        return;
-      }
-  });
+const savedRouteModel = savedRouteSchema;
+router.get("/", valCookie, async function (req, res) {
+  try {
+    let { cookies } = req;
+    let individual = await LoginModel.find({ accessToken: cookies.session_id });
+    let savedRoutes = await savedRouteModel.find({
+      email: individual[0]["email"],
+    });
+    let arr = [];
+    for (let i = 0; i < savedRoutes.length; i++) {
+      arr.push(savedRoutes[i]);
+    }
+    res.send(arr);
+  } catch (error) {
+    res.send({ error: error });
+    return;
+  }
+});
 
+router.post("/", valCookie, async function (req, res) {
+  try {
+    let { cookies } = req;
+    let individual = await LoginModel.find({ accessToken: cookies.session_id });
+    let duplicateCheck = await savedRouteModel.find({
+      email: individual[0]["email"],
+      name: req.body["name"],
+    });
+    if (duplicateCheck.length !== 0) {
+      res.send({ exists: 1 });
+      return;
+    }
+    let newSavedRoutes = new savedRouteModel({
+      email: individual[0]["email"],
+      origin: req.body["origin"],
+      destination: req.body["destination"],
+      name: req.body["name"],
+    });
+    await newSavedRoutes.save();
+    let savedRoutes = await savedRouteModel.find({
+      email: individual[0]["email"],
+    });
+    let arr = [];
+    for (let i = 0; i < savedRoutes.length; i++) {
+      arr.push(savedRoutes[i]);
+    }
+    res.send({ exists: 0, results: arr });
+  } catch (error) {
+    res.send({ error: error });
+    return;
+  }
+});
 
-  router.put('/', valCookie,async function(req, res) {
-    try{
-      let { cookies } = req;
-      let individual = await LoginModel.find({ accessToken: cookies.session_id });
-      let duplicateCheck= await savedRouteModel.find({email: individual[0]["email"],name:req.body["name"]});
-      if (duplicateCheck.length!==0) {
-        res.send({exists:1});
-        return
-      }
-      let newSavedRoutes= new savedRouteModel({email: individual[0]["email"],origin:req.body["origin"],destination:req.body["destination"], name:req.body["name"]});
-      await newSavedRoutes.save();
-      let savedRoutes= await savedRouteModel.find({email: individual[0]["email"]});
-      let arr=[];
-      for (let i=0;i<savedRoutes.length;i++){
-        arr.push(savedRoutes[i]);
-      }
-      res.send({exists:0,results:arr});
-      } catch(error){
-        res.send({"error":error});
-        return;
-      }
-  });
+router.put("/", valCookie, async function (req, res) {
+  å;
+  try {
+    let { cookies } = req;
+    let individual = await LoginModel.find({ accessToken: cookies.session_id });
+    let duplicateCheck = await savedRouteModel.find({
+      email: individual[0]["email"],
+      name: req.body["name"],
+    });
+    if (duplicateCheck.length !== 0) {
+      res.send({ exists: 1 });
+      return;
+    }
+    let newSavedRoutes = new savedRouteModel({
+      email: individual[0]["email"],
+      origin: req.body["origin"],
+      destination: req.body["destination"],
+      name: req.body["name"],
+    });
+    await newSavedRoutes.save();
+    let savedRoutes = await savedRouteModel.find({
+      email: individual[0]["email"],
+    });
+    let arr = [];
+    for (let i = 0; i < savedRoutes.length; i++) {
+      arr.push(savedRoutes[i]);
+    }
+    res.send({ exists: 0, results: arr });
+  } catch (error) {
+    res.send({ error: error });
+    return;
+  }
+});
 
+router.delete("/", valCookie, async function (req, res) {
+  try {
+    let { cookies } = req;
+    let individual = await LoginModel.find({ accessToken: cookies.session_id });
+    let savedRoutes = await savedRouteModel.deleteOne({
+      email: individual[0]["email"],
+      origin: req.body["origin"],
+      destionation: req.body["destination"],
+      name: req.body["name"],
+    });
+    let newArr = await savedRouteModel.find({ email: individual[0]["email"] });
 
-  router.delete('/', valCookie,async function(req, res) {
-    try{
-      let { cookies } = req;
-      let individual = await LoginModel.find({ accessToken: cookies.session_id });
-      let savedRoutes= await savedRouteModel.deleteOne({email: individual[0]["email"],origin:req.body["origin"],destionation:req.body["destination"],name:req.body["name"]});
-      let newArr=await savedRouteModel.find({email: individual[0]["email"]});
-
-      let arr=[];
-      for (let i=0;i<newArr.length;i++){
+    let arr = [];
+    for (let i = 0; i < newArr.length; i++) {
       arr.push(newArr[i]);
-      }
-      res.send(arr);
-      } catch(error){
-        res.send({"error":error});
-        return;
-      }
-  });
-
+    }
+    res.send(arr);
+  } catch (error) {
+    res.send({ error: error });
+    return;
+  }
+});
 
 module.exports = router;


### PR DESCRIPTION
# PR Description

This PR adds functionality to tie in with the backend changes added in #72, allowing users to specify routes that they want to save on the frontend. These changes introduce:
- inputs in the top left component to name and save a route based on what is currently in the `Autocomplete` components.
- dropdowns and chips on the bottom left `Details` component to display currently saved routes and their details from the backend
- new async functions to liaise with backend endpoints
- various reducers and actions on frontend to coordinate states between the different components
- changed delete endpoint to a PUT endpoint to clear all queries (hadn't had time to implement deleting a single route yet)
- some formatting changes caused by linter auto-save

## Linked Issues
- closes #31 
